### PR TITLE
Current value is incorrectly reported with multiple open positions

### DIFF
--- a/lib/cryptofolio/web/templates/portfolio/index.html.eex
+++ b/lib/cryptofolio/web/templates/portfolio/index.html.eex
@@ -107,7 +107,7 @@ e     class="portfolio-pie"
       <td><%= format_money(coin_trades_cost(coin_trades), @fiat) %></td>
       <td><%= format_money(coin_trades_total_cost(coin_trades), @fiat) %></td>
       <td><%= format_money(List.first(coin_trades).currency.cost_usd, @fiat) %></td>
-      <td><%= format_money(List.first(coin_trades).current_value, @fiat) %></td>
+      <td><%= format_money(coin_trades_current_value(coin_trades), @fiat) %></td>
       <td>
         <span class="<%= class_for_value(coin_trades_profit_lost(coin_trades)) %>">
           <%= format_money(coin_trades_profit_lost(coin_trades), @fiat) %>

--- a/lib/cryptofolio/web/views/portfolio_view.ex
+++ b/lib/cryptofolio/web/views/portfolio_view.ex
@@ -52,6 +52,10 @@ defmodule Cryptofolio.Web.PortfolioView do
     Enum.reduce(trades, Decimal.new(0), fn(trade, acc) -> Decimal.add(Trade.profit_loss(trade), acc) end)
   end
 
+  def coin_trades_current_value(trades) do
+    Decimal.mult(List.first(trades).currency.cost_usd, coin_trades_amount(trades))
+  end
+
   def coin_trades_profit_lost_perc(trades) do
     total_cost = coin_trades_total_cost(trades)
 


### PR DESCRIPTION
Currently, the way the application is laid out, the current value field on the dashboard only reports the current value of the first item in the list.

This is OK if you only have one open position, but if you are holding a currency with multiple open positions, it incorrectly reports the current value by displaying the value of the first item in the list.

This proposed change resolves this issue by taking the value of coin_trades_amount and multiplying it against List.first(trades).currency.cost_usd